### PR TITLE
Initial WP_Comment support.

### DIFF
--- a/src/Type/CommentType.php
+++ b/src/Type/CommentType.php
@@ -1,0 +1,94 @@
+<?php
+namespace BEForever\WPGraphQL\Type;
+
+use BEForever\WPGraphQL\AppContext;
+use BEForever\WPGraphQL\Data\User;
+use BEForever\WPGraphQL\TypeSystem;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+
+class CommentType extends BaseType {
+	public function __construct( TypeSystem $types ) {
+		$this->definition = new ObjectType([
+			'name' => 'Comment',
+			'fields' => function() use ( $types ) {
+				return array(
+					'id'           => $types->id(),
+					'post'         => $types->id(),
+					'author'       => $types->string(),
+					'author_ip'    => $types->string(),
+					'date'         => $types->string(),
+					'date_gmt'     => $types->string(),
+					'content'      => $types->string(),
+					'karma'        => $types->int(),
+					'approved'     => $types->string(),
+					'agent'        => $types->string(),
+					'type'         => $types->string(),
+					'parent'       => $types->string(),
+					'user_id'      => $types->id(),
+				);
+			},
+			'interfaces' => [
+				$types->node(),
+			],
+			'resolveField' => function( $value, $args, $context, ResolveInfo $info ) {
+				if ( method_exists( $this, $info->fieldName ) ) {
+					return $this->{$info->fieldName}( $value, $args, $context, $info );
+				} else {
+					return $value->{$info->fieldName};
+				}
+			},
+		]);
+	}
+
+	// Testing to see if it will resolve based on interface.
+	public function id( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->ID;
+	}
+
+	public function post( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->comment_post_ID;
+	}
+
+	/**
+	 * This for whatever reason is the author name not id for the author.
+	 */
+	public function author( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->comment_author;
+	}
+
+	public function author_ip( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->comment_author_IP;
+	}
+
+	public function content( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->comment_content;
+	}
+
+	public function karma( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->comment_karma;
+	}
+
+	public function approved( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->comment_approved;
+	}
+
+	public function agent( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->comment_agent;
+	}
+
+	public function type( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->comment_type;
+	}
+
+	public function parent( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->comment_parent;
+	}
+
+	/**
+	 * ID of comment author.
+	 */
+	public function user_id( \WP_Comment $comment, $args, AppContext $context) {
+		return $comment->user_id;
+	}
+}

--- a/src/Type/NodeType.php
+++ b/src/Type/NodeType.php
@@ -47,6 +47,8 @@ class NodeType extends BaseType {
 			return $types->user();
 		} elseif ( $object instanceof Post ) {
 			return $types->post();
+		} elseif ( $object instanceof Comment ) {
+			return $types->comment();
 		}
 	}
 }

--- a/src/Type/QueryType.php
+++ b/src/Type/QueryType.php
@@ -27,7 +27,14 @@ class QueryType extends BaseType {
 				],
 				'user' => [
 					'type' => $types->user(),
-					'description' => 'Returns user by id (in range of 1-5)',
+					'description' => 'Returns user by id',
+					'args' => [
+						'id' => $types->nonNull( $types->id() ),
+					],
+				],
+				'comment' => [
+					'type' => $types->comment(),
+					'description' => 'Returns comment by id',
 					'args' => [
 						'id' => $types->nonNull( $types->id() ),
 					],
@@ -55,6 +62,20 @@ class QueryType extends BaseType {
 	}
 
 	/**
+	 * Comment field resolver.
+	 *
+	 * Note that comment is a field within the query type.
+	 *
+	 * @param mixed      $value   Value for the resolver.
+	 * @param array      $args    List of arguments for this resolver.
+	 * @param AppContext $context Context object for the Application.
+	 * @return WP_Comment Comment object.
+	 */
+	public function comment( $value, $args, AppContext $context ) {
+		return get_comment( $args['id'] );
+	}
+
+	/**
 	 * User field resolver.
 	 *
 	 * Note that user is a field within the user type.
@@ -62,7 +83,7 @@ class QueryType extends BaseType {
 	 * @param mixed      $value   Value for the resolver.
 	 * @param array      $args    List of arguments for this resolver.
 	 * @param AppContext $context Context object for the Application.
-	 * @return WP_Post Post object.
+	 * @return WP_User User object.
 	 */
 	public function user( $value, $args, AppContext $context ) {
 		return get_user_by( 'id', $args['id'] );

--- a/src/TypeSystem.php
+++ b/src/TypeSystem.php
@@ -40,6 +40,11 @@ class TypeSystem {
 	private $user;
 
 	/**
+	 * Comment object type.
+	 */
+	private $comment;
+
+	/**
 	 * User object type.
 	 */
 	private $query;
@@ -56,6 +61,13 @@ class TypeSystem {
 	 */
 	public function user() {
 		return $this->user ?: ( $this->user = new UserType( $this ) );
+	}
+
+	/**
+	 * @return CommentType
+	 */
+	public function comment() {
+		return $this->comment ?: ( $this->comment = new CommentType( $this ) );
 	}
 
 	/**

--- a/tests/test-query.php
+++ b/tests/test-query.php
@@ -148,6 +148,83 @@ class Query_Test extends WP_UnitTestCase {
 	/**
 	 * Tests the query for post.
 	 */
+	function test_comment_query() {
+		$comment_args = array(
+			'comment_approved' => '1',
+			'comment_content' => 'Hi!',
+		);
+
+		$comment_id = $this->factory->comment->create( $comment_args );
+
+		$query = "{ comment(id: {$comment_id}) { content, approved } }";
+		$expected = array(
+			'data' => array(
+				'comment' => array(
+					'content' => 'Hi!',
+					'approved' => '1',
+				),
+			),
+		);
+
+		// Build the complete type system.
+		$type_system = new TypeSystem();
+
+		// Build request context that will be available in all field resolvers (as 3rd argument).
+		$app_context = new AppContext();
+
+		// Build GraphQL schema out of the query object type.
+		$schema = new Schema([
+			'query' => $type_system->query(),
+		]);
+
+		$data = array();
+		$data['query'] = $query;
+		$data['variables'] = null;
+
+		// Execute the query.
+		$result = GraphQL::execute(
+			$schema,
+			$data['query'],
+			null,
+			$app_context,
+			(array) $data['variables'],
+			null
+		);
+
+		$this->assertEquals( $result, $expected );
+	}
+
+	/**
+	 * Tests the fields schema for comments.
+	 */
+	function test_comment_introspection_fields() {
+		$query = '{__type(name: "Comment") {fields {name}}}';
+		$expected = array(
+			'data' => array(
+				'__type' => array(
+					'fields' => array(
+						array( 'name' => 'id' ),
+						array( 'name' => 'post' ),
+						array( 'name' => 'author' ),
+						array( 'name' => 'author_ip' ),
+						array( 'name' => 'date' ),
+						array( 'name' => 'date_gmt' ),
+						array( 'name' => 'content' ),
+						array( 'name' => 'karma' ),
+						array( 'name' => 'approved' ),
+						array( 'name' => 'agent' ),
+						array( 'name' => 'type' ),
+						array( 'name' => 'parent' ),
+						array( 'name' => 'user_id' ),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests the query for post.
+	 */
 	function test_user_query() {
 		$user_args = array(
 			'role'       => 'editor',


### PR DESCRIPTION
Fixes #5. This is the first take of adding Comment support. This is just
for the comment base type.  Fields and implementation are subject to
change.