### PR TITLE
Add author edge for the comment type.

### DIFF
--- a/src/Type/CommentType.php
+++ b/src/Type/CommentType.php
@@ -15,7 +15,7 @@ class CommentType extends BaseType {
 				return array(
 					'id'           => $types->id(),
 					'post'         => $types->id(),
-					'author'       => $types->string(),
+					'author'       => $types->user(),
 					'author_ip'    => $types->string(),
 					'date'         => $types->string(),
 					'date_gmt'     => $types->string(),
@@ -54,7 +54,7 @@ class CommentType extends BaseType {
 	 * This for whatever reason is the author name not id for the author.
 	 */
 	public function author( \WP_Comment $comment, $args, AppContext $context) {
-		return $comment->comment_author;
+		return get_user_by( 'id', $comment->comment_author );
 	}
 
 	public function author_ip( \WP_Comment $comment, $args, AppContext $context) {

--- a/tests/test-query.php
+++ b/tests/test-query.php
@@ -611,17 +611,21 @@ class Query_Test extends WP_UnitTestCase {
 		$comment_args = array(
 			'comment_approved' => '1',
 			'comment_content' => 'Hi!',
+			'comment_author' => $this->admin,
 		);
 
 		$comment_id = $this->factory->comment->create( $comment_args );
 
-		$query = '{ comments(first: 2) { id, content } }';
+		$query = '{ comments(first: 2) { id, content, author { id } } }';
 		$expected = array(
 			'data' => array(
 				'comments' => array(
 					array(
 						'id' => $comment_id,
 						'content' => 'Hi!',
+						'author' => array(
+							'id' => $this->admin,
+						),
 					),
 				),
 			),


### PR DESCRIPTION
Fixes #45. Makes the author field for a comment an edge to the user object node.
This enables the user to get necessary information about the comments.