### PR TITLE
Add post type(s) support.

### DIFF
--- a/src/Type/PostTypeType.php
+++ b/src/Type/PostTypeType.php
@@ -1,0 +1,48 @@
+<?php
+namespace BEForever\WPGraphQL\Type;
+
+use BEForever\WPGraphQL\AppContext;
+use BEForever\WPGraphQL\Data\User;
+use BEForever\WPGraphQL\TypeSystem;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+
+class PostTypeType extends BaseType {
+	public function __construct( TypeSystem $types ) {
+		$this->definition = new ObjectType([
+			'name' => 'PostType',
+			'fields' => function() use ( $types ) {
+				return array(
+					'name' => $types->string(),
+					'label' => $types->string(),
+					//'labels' => $types->post_type_labels(),
+					'description' => $types->string(),
+					'public' => $types->boolean(),
+					'hierarchical' => $types->boolean(),
+					'exclude_from_search' => $types->boolean(),
+					'publicly_queryable' => $types->boolean(),
+					'show_ui' => $types->boolean(),
+					'show_in_menu' => $types->boolean(),
+					'show_in_nav_menus' => $types->boolean(),
+					'show_in_admin_bar' => $types->boolean(),
+					'menu_position' => $types->int(),
+					'menu_icon' => $types->string(),
+					'taxonomies' => $types->listOf( $types->string() ),
+					'has_archive' => $types->boolean(),
+					'can_export' => $types->boolean(),
+					'delete_with_user' => $types->boolean(),
+					'show_in_rest' => $types->boolean(),
+					'rest_base' => $types->string(),
+					'rest_controller_class' => $types->string(),
+				);
+			},
+			'resolveField' => function( $value, $args, $context, ResolveInfo $info ) {
+				if ( method_exists( $this, $info->fieldName ) ) {
+					return $this->{$info->fieldName}( $value, $args, $context, $info );
+				} else {
+					return $value->{$info->fieldName};
+				}
+			},
+		]);
+	}
+}

--- a/src/Type/QueryType.php
+++ b/src/Type/QueryType.php
@@ -157,6 +157,17 @@ class QueryType extends BaseType {
 						'after' => $types->int(),
 					],
 				],
+				'post_type' => [
+					'type' => $types->post_type(),
+					'description' => 'Returns registered post type',
+					'args' => [
+						'name' => $types->string(),
+					],
+				],
+				'post_types' => [
+					'type' => $types->listOf( $types->post_type() ),
+					'description' => 'Returns registered post types',
+				],
 				'hello' => Type::string(),
 			],
 			'resolveField' => function( $value, $args, $context, ResolveInfo $info ) {
@@ -508,6 +519,39 @@ class QueryType extends BaseType {
 		}
 
 		return ! empty( $plugins ) ? $plugins : null;
+	}
+
+	/**
+	 * Post types field resolver.
+	 *
+	 * @param mixed      $value   Value for the resolver.
+	 * @param array      $args    List of arguments for this resolver.
+	 * @param AppContext $context Context object for the Application.
+	 * @return array Array of plugin data.
+	 */
+	public function post_type( $value, $args, AppContext $context ) {
+		$post_types = get_post_types( '', 'objects' );
+		$post_type = array();
+
+		foreach ( $post_types as $type ) {
+			if ( $args['name'] === $type->name ) {
+				$post_type = $type;
+			}
+		}
+
+		return ! empty( $post_type ) ? $post_type : null;
+	}
+
+	/**
+	 * Post types field resolver.
+	 *
+	 * @param mixed      $value   Value for the resolver.
+	 * @param array      $args    List of arguments for this resolver.
+	 * @param AppContext $context Context object for the Application.
+	 * @return array Array of plugin data.
+	 */
+	public function post_types( $value, $args, AppContext $context ) {
+		return get_post_types( array(), 'objects' );
 	}
 
 	/**

--- a/src/TypeSystem.php
+++ b/src/TypeSystem.php
@@ -11,6 +11,7 @@ use BEForever\WPGraphQL\Type\MenuType;
 use BEForever\WPGraphQL\Type\MenuLocationType;
 use BEForever\WPGraphQL\Type\ThemeType;
 use BEForever\WPGraphQL\Type\PluginType;
+use BEForever\WPGraphQL\Type\PostTypeType;
 use BEForever\WPGraphQL\Type\NodeType;
 use BEForever\WPGraphQL\Type\QueryType;
 use GraphQL\Type\Definition\ListOfType;
@@ -77,6 +78,11 @@ class TypeSystem {
 	 * Plugin object type.
 	 */
 	private $plugin;
+
+	/**
+	 * Post type object type.
+	 */
+	private $post_type;
 
 	/**
 	 * Query object type.
@@ -151,6 +157,13 @@ class TypeSystem {
 	 */
 	public function plugin() {
 		return $this->plugin ?: ( $this->plugin = new PluginType( $this ) );
+	}
+
+	/**
+	 * @return PostTypeType
+	 */
+	public function post_type() {
+		return $this->post_type ?: ( $this->post_type = new PostTypeType( $this ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #62.  This adds basic support for post type querying.  This should
probably be renamed to types as post types is a name specific to
WordPress even though custom post types can be a much broader spectrum.