### PR TITLE
Fix Travis CI for better testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,14 @@ branches:
 matrix:
   include:
     - php: 5.4
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 5.5
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 5.6
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 7.0
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 5.4
       env: WP_VERSION=latest WP_MULTISITE=1
     - php: 5.5
       env: WP_VERSION=latest WP_MULTISITE=1
@@ -22,6 +30,8 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=1
     - php: 7.0
       env: WP_VERSION=latest WP_MULTISITE=1
+    - php: 7.0
+      env: WP_VERSION=nightly WP_MULTISITE=0
   fast_finish: true
 
 cache:


### PR DESCRIPTION
Fixes #28. This fixes the test suite from only running multisite, it
also adds a test against the nightly build of WordPress on PHP 7.0