### PR TITLE
Add Term Parent

### DIFF
--- a/src/Type/TermType.php
+++ b/src/Type/TermType.php
@@ -87,7 +87,7 @@ class TermType extends BaseType {
 	}
 
 	public function parent( \WP_Term $term, $args, AppContext $context ) {
-		return new \WP_Term( $term->parent );
+		return get_term( $term->parent );
 	}
 
 	public function group( \WP_Term $term, $args, AppContext $context ) {

--- a/src/Type/TermType.php
+++ b/src/Type/TermType.php
@@ -42,8 +42,8 @@ class TermType extends BaseType {
 						'description' => esc_html__( 'The description for the term. This field is equivalent to WP_Term->description', 'wp-graphql' ),
 					),
 					'parent'          => array(
-						'type'        => $types->id(),
-						'description' => esc_html__( 'The id for the parent term. Terms can be hierarchically organized in one to many relationships. This field is equivalent to WP_Term->parent', 'wp-graphql' ),
+						'type'        => $types->term(),
+						'description' => esc_html__( 'The parent term. Terms can be hierarchically organized in one to many relationships. This field is equivalent to new WP_Term( WP_Term->parent )', 'wp-graphql' ),
 					),
 					'count'           => array(
 						'type'        => $types->int(),
@@ -84,6 +84,10 @@ class TermType extends BaseType {
 
 	public function id( \WP_Term $term, $args, AppContext $context ) {
 		return $term->term_id;
+	}
+
+	public function parent( \WP_Term $term, $args, AppContext $context ) {
+		return new WP_Term( $term->parent );
 	}
 
 	public function group( \WP_Term $term, $args, AppContext $context ) {

--- a/src/Type/TermType.php
+++ b/src/Type/TermType.php
@@ -87,7 +87,7 @@ class TermType extends BaseType {
 	}
 
 	public function parent( \WP_Term $term, $args, AppContext $context ) {
-		return new WP_Term( $term->parent );
+		return new \WP_Term( $term->parent );
 	}
 
 	public function group( \WP_Term $term, $args, AppContext $context ) {

--- a/tests/test-query.php
+++ b/tests/test-query.php
@@ -463,6 +463,44 @@ class Query_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the query for term.
+	 */
+	public function test_term_parent_query() {
+		$term_args = array(
+			'taxonomy' => 'category',
+			'name'     => 'Test',
+		);
+
+		$term_id = $this->factory->term->create( $term_args );
+
+		$child_args = array(
+			'taxonomy' => 'category',
+			'name'     => 'Child',
+			'parent'   => $term_id,
+		);
+
+		$child_id = $this->factory->term->create( $child_args );
+
+		$query = "{ term(id: {$child_id}) { name, parent { name } } }";
+
+		$actual = $this->get_graphql_response( $query );
+		$expected = array(
+			'data' => array(
+				'term' => array(
+					'name' => 'Child',
+					'parent' => array(
+						array(
+							'name' => 'Test',
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
 	 * Tests the query for term fields.
 	 */
 	public function test_term_introspection_fields() {

--- a/tests/test-query.php
+++ b/tests/test-query.php
@@ -489,9 +489,7 @@ class Query_Test extends WP_UnitTestCase {
 				'term' => array(
 					'name' => 'Child',
 					'parent' => array(
-						array(
-							'name' => 'Test',
-						),
+						'name' => 'Test',
 					),
 				),
 			),


### PR DESCRIPTION
Fixes #97. Currently the term parent field only returns the id not the
relating edge.