### PR TITLE
Add dynamic post type collections.

### DIFF
--- a/src/Type/PostInterfaceType.php
+++ b/src/Type/PostInterfaceType.php
@@ -135,18 +135,6 @@ class PostInterfaceType extends BaseType {
 	 * @param TypeSystem $types  Current TypeSystem.
 	 */
 	public function resolveType( $object, TypeSystem $types ) {
-		if ( $object instanceof User ) {
-			return $types->user();
-		} elseif ( $object instanceof Post ) {
-			return $types->post();
-		} elseif ( $object instanceof Comment ) {
-			return $types->comment();
-		} elseif ( $object instanceof Term ) {
-			return $types->term();
-		} elseif ( $object instanceof MenuItem ) {
-			return $types->menu_item();
-		} elseif ( $object instanceof Menu ) {
-			return $types->menu();
-		}
+		return $types->post_object( $object->post_type );
 	}
 }

--- a/src/Type/PostObjectType.php
+++ b/src/Type/PostObjectType.php
@@ -7,13 +7,13 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 
 class PostObjectType extends BaseType {
-	private $post_type;
+	public $post_type;
 
 	public function __construct( TypeSystem $types, $post_type ) {
 		$this->post_type = $post_type;
 
 		$this->definition = new ObjectType([
-			'name' => ucfirst( $post_type ),
+			'name' => $post_type,
 			'fields' => function() use ( $types ) {
 				return array(
 					'id'              => array(

--- a/src/Type/PostType.php
+++ b/src/Type/PostType.php
@@ -6,6 +6,13 @@ use BEForever\WPGraphQL\TypeSystem;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 
+/**
+ * The post type must remain for now to match up as a general type for edges of
+ * other types. For example terms can return a collection of posts, assigned to
+ * them. This type will be useful for these scenarios where a collection of
+ * different post types could be used. Or the posts of an author, that could be
+ * pages, posts, or custom post types all mixed together.
+ */
 class PostType extends BaseType {
 	public function __construct( TypeSystem $types ) {
 		$this->definition = new ObjectType([

--- a/src/TypeSystem.php
+++ b/src/TypeSystem.php
@@ -111,8 +111,11 @@ class TypeSystem {
 		$this->wp_config = $wp_config;
 
 		if ( isset( $wp_config['post_types'] ) && is_array( $wp_config['post_types'] ) ) {
-			foreach ( $wp_config['post_types'] as $post_type ) {
-				$this->{$post_type} = new PostObjectType( $this, $post_type );
+			foreach ( $wp_config['post_types'] as $type => $post_type ) {
+				$single      = $post_type['name'];
+				$single_type = $post_type['singular_type'];
+
+				$this->{$single} = new PostObjectType( $this, $single_type );
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #117.  Adds in the initial set up for dynamic posts collection.
The generic PostType should remain to ensure collections of many
different types are still possible via `$types->listOf( $types->post()
)`.