### PR TITLE
Add proper resolving for taxonomy field on term.

### DIFF
--- a/src/Type/TermType.php
+++ b/src/Type/TermType.php
@@ -29,13 +29,9 @@ class TermType extends BaseType {
 						'type'        => $types->string(),
 						'description' => esc_html__( 'Group for the term. Groups of terms can be used for performance enhancements while querying they act like a secondary index in SQL. The group field is equivalent to WP_Term->term_group or the `term_group` field in SQL.', 'wp-graphql' ),
 					),
-					'taxonomy_id'     => array(
-						'type'        => $types->id(),
-						'description' => esc_html__( "The id of the term's taxonomy. This field is equivalent to WP_Term->taxonomy_id", 'wp-graphql' ),
-					),
 					'taxonomy'        => array(
-						'type'        => $types->string(),
-						'description' => esc_html__( "The display name of the term's taxonomy. This field is equivalent to WP_Term->taxonomy", 'wp-graphql' ),
+						'type'        => $types->taxonomy(),
+						'description' => esc_html__( 'The taxonomy the term belongs to.', 'wp-graphql' ),
 					),
 					'description'     => array(
 						'type'        => $types->string(),
@@ -108,6 +104,10 @@ class TermType extends BaseType {
 
 	public function group( \WP_Term $term, $args, AppContext $context ) {
 		return $term->term_group;
+	}
+
+	public function taxonomy( \WP_Term $term, $args, AppContext $context ) {
+		return get_taxonomy( $term->taxonomy );
 	}
 
 	public function children( \WP_Term $term, $args, AppContext $context ) {

--- a/tests/test-query.php
+++ b/tests/test-query.php
@@ -561,12 +561,37 @@ class Query_Test extends WP_UnitTestCase {
 
 		$term_id = $this->factory->term->create( $term_args );
 
-		$query = "{ term(id: {$term_id}) { taxonomy, name } }";
+		$query = "{ term(id: {$term_id}) { id, name } }";
 		$expected = array(
 			'data' => array(
 				'term' => array(
-					'taxonomy' => 'category',
-					'name'     => 'Test',
+					'id'   => $term_id,
+					'name' => 'Test',
+				),
+			),
+		);
+
+		$this->check_graphql_response( $query, $expected );
+	}
+
+	/**
+	 * Tests the query for term.
+	 */
+	public function test_term_taxonomy_edge_query() {
+		$term_args = array(
+			'taxonomy' => 'category',
+			'name'     => 'Test',
+		);
+
+		$term_id = $this->factory->term->create( $term_args );
+
+		$query = "{ term(id: {$term_id}) { taxonomy { name } } }";
+		$expected = array(
+			'data' => array(
+				'term' => array(
+					'taxonomy' => array(
+						'name' => 'Categories',
+					),
 				),
 			),
 		);
@@ -722,7 +747,6 @@ class Query_Test extends WP_UnitTestCase {
 						array( 'name' => 'name' ),
 						array( 'name' => 'slug' ),
 						array( 'name' => 'group' ),
-						array( 'name' => 'taxonomy_id' ),
 						array( 'name' => 'taxonomy' ),
 						array( 'name' => 'description' ),
 						array( 'name' => 'parent' ),
@@ -1360,18 +1384,16 @@ class Query_Test extends WP_UnitTestCase {
 
 		$term_id = $this->factory->term->create( $term_args );
 
-		$query = '{ terms{ name, taxonomy, count } }';
+		$query = '{ terms{ name, count } }';
 		$expected = array(
 			'data' => array(
 				'terms' => array(
 					array(
 						'name' => 'Test',
-						'taxonomy' => 'post_tag',
 						'count' => 0,
 					),
 					array(
 						'name' => 'Uncategorized',
-						'taxonomy' => 'category',
 						'count' => 0,
 					),
 				),


### PR DESCRIPTION
Fixes #139. Adds the edge to the taxonomy for a term.  This removes the
taxonomy id field and replaces the taxonomy field with an edge resolving
to a taxonomy.